### PR TITLE
added `baseClass` type

### DIFF
--- a/src/lib/@types/index.d.ts
+++ b/src/lib/@types/index.d.ts
@@ -17,6 +17,10 @@ declare module 'react-simple-keyboard' {
   }
 
   interface KeyboardOptions {
+     /**
+    * Sets a personalized unique id
+    */
+    baseClass?: string;
     /**
      * Modify the keyboard layout.
      */


### PR DESCRIPTION
## Description

Added `baseClass` type for KeyboardOptions interface

## Checks

- [x] Tests ( `npm run test -- --coverage` ) Coverage at `./coverage/lcov-report/index.html` should be 100%